### PR TITLE
ライブラリ本体がリポジトリに含まれている

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore gem libraries.
+/vendor/bundle
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal


### PR DESCRIPTION
`.gitignore`に対するコミット(ed43501)内で`/vendor/bundle`の[記述が消えている](https://github.com/OCTPC/newstyle/commit/ed4350179c027e06d0d09a8fb62d86d9f844c182#diff-a084b794bc0759e7a6b77810e01874f2L25)ため、その後のコミット(a27a73f5fa075aa79326df3eb6731fbdd8099742)において、ライブラリの本体がリポジトリに含まれています。
このコミットについては、GitHub上で開こうとすると固まるほど重くなる状態です。

ライブラリについては、`Gemfile`、`Gemfile.lock`で必要なものを列挙し、`bundle install`で各環境にインストールするのが一般的ですが、おそらくネイティブでビルドされたバイナリも含まれているため、リポジトリのサイズが36MB近くに肥大化しています。

これにより、初回クローン時をはじめ通信に時間とコストがかかる状況になっています。
このPRを取り込んだ時点では、`vendor/bundle`配下の内容がトラックされなくなりますが、Gitの仕組み上コミットを消去することはできないため、ずっとついてまわる問題になります。

これを修正する場合は、この`.gitignore`への記述を前提にコミット a27a73f5f の直前まで遡ってから、cherry-pickで以降の変更を取り込むことが比較的負担がないものと思われます。
