### PR TITLE
db/migrate/20161001062014_add_category_to_contents.rbの内容を他のファイルと合わせる

### DIFF
--- a/db/migrate/20161001062014_add_category_to_contents.rb
+++ b/db/migrate/20161001062014_add_category_to_contents.rb
@@ -1,5 +1,11 @@
 class AddCategoryToContents < ActiveRecord::Migration
   def change
-    add_column :content, :category, :string
+    create_table :categories do |t|
+      t.string :content
+      t.string :category
+      t.string :string
+
+      t.timestamps null: false
+    end
   end
 end

--- a/db/migrate/20161001062014_add_category_to_contents.rb
+++ b/db/migrate/20161001062014_add_category_to_contents.rb
@@ -1,6 +1,6 @@
 class AddCategoryToContents < ActiveRecord::Migration
   def change
-    create_table :categories do |t|
+    create_table :contents do |t|
       t.string :content
       t.string :category
       t.string :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,18 +13,12 @@
 
 ActiveRecord::Schema.define(version: 20161004125921) do
 
-  create_table "contents", force: :cascade do |t|
-    t.text     "title"
-    t.text     "url"
-    t.text     "summary"
-    t.text     "body"
-    t.text     "keyword"
-    t.text     "trend"
-    t.datetime "time"
-    t.text     "author"
+  create_table "categories", force: :cascade do |t|
+    t.string   "content"
+    t.string   "category"
+    t.string   "string"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "category"
   end
 
   create_table "keywords", force: :cascade do |t|


### PR DESCRIPTION
明らかに内容がおかしかったせいで`rake db:migrate`が動かなかったので    
このコミットによって`rake db:migrate`が正常に終了することを確認しました。